### PR TITLE
Feat: exclude from graph with `#graph-exclude` tag

### DIFF
--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -1,6 +1,19 @@
 import { PageLayout, SharedLayout } from "./quartz/cfg"
 import * as Component from "./quartz/components"
 
+// MMW: hiding notes from graph via tags
+const tagsToRemove = ["graph-exclude"]
+const graphConfig = {
+  localGraph: {
+    removeTags: tagsToRemove,
+    excludeTags: ["graph-exclude"]
+  },
+  globalGraph: {
+    removeTags: tagsToRemove,
+    excludeTags: ["graph-exclude"]
+  }
+};
+
 // components shared across all pages
 export const sharedPageComponents: SharedLayout = {
   head: Component.Head(),
@@ -38,7 +51,7 @@ export const defaultContentPageLayout: PageLayout = {
       folderClickBehavior: "link", 
       filterFn: (node) => node.name !== "Templates",
     })),
-    Component.DesktopOnly(Component.Graph()),
+    Component.DesktopOnly(Component.Graph(graphConfig)),
     Component.DesktopOnly(Component.TableOfContents()),
     Component.Backlinks(),
   ],
@@ -62,7 +75,7 @@ export const defaultListPageLayout: PageLayout = {
       folderClickBehavior: "link", 
       filterFn: (node) => node.name !== "Templates",
     })),
-    Component.DesktopOnly(Component.Graph()),
+    Component.DesktopOnly(Component.Graph(graphConfig)),
     Component.DesktopOnly(Component.TableOfContents()),
     Component.Backlinks(),
   ],

--- a/quartz/components/scripts/graph.inline.ts
+++ b/quartz/components/scripts/graph.inline.ts
@@ -87,13 +87,20 @@ async function renderGraph(container: string, fullSlug: FullSlug) {
     removeTags,
     showTags,
     focusOnHover,
+    excludeTags,
   } = JSON.parse(graph.dataset["cfg"]!) as D3Config
 
-  const data: Map<SimpleSlug, ContentDetails> = new Map(
+  const originalData: Map<SimpleSlug, ContentDetails> = new Map(
     Object.entries<ContentDetails>(await fetchData).map(([k, v]) => [
       simplifySlug(k as FullSlug),
       v,
     ]),
+  )
+  // MMW: Take out files that have the tags in excludeTags
+  const data: Map<SimpleSlug, ContentDetails> = new Map(
+    [...originalData.entries()].filter(([key, value]) => {
+    return !value.tags?.some(tag => excludeTags.includes(tag))
+    })
   )
   const links: SimpleLinkData[] = []
   const tags: SimpleSlug[] = []


### PR DESCRIPTION
Notes can be excluded from the graph view by adding the tag `#graph-exclude`.

Use-case: Maintenance Templates which are embedded in a page can clutter up the graph. Excluding these gives a better picture of how the actual *content* of the site is interconnected.